### PR TITLE
Use intrusive list in VisitedListPool

### DIFF
--- a/cpp/deglib/include/intrusive_list.h
+++ b/cpp/deglib/include/intrusive_list.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <utility>
+
+namespace deglib::graph {
+
+/*
+Usage:
+
+``` 
+struct Entry {
+    Entry* next_; // list hooks
+    Entry* prev_; // list hooks
+    // ... other members
+};
+
+using List = IntrusiveList<Entry, &Entry::next_, &Entry::prev_>;
+```
+
+Make sure entries added to the list have a stable address.
+
+
+Implementation adapted from
+https://github.com/facebookexperimental/libunifex/blob/main/include/unifex/detail/intrusive_list.hpp
+ */
+template <class T, T* T::*Next, T* T::*Prev>
+class IntrusiveList
+{
+  private:
+    T* head_{};
+    T* tail_{};
+
+  public:
+    IntrusiveList() = default;
+
+    IntrusiveList(const IntrusiveList&) = delete;
+
+    IntrusiveList(IntrusiveList&& other) noexcept
+        : head_(std::exchange(other.head_, nullptr)), tail_(std::exchange(other.tail_, nullptr))
+    {
+    }
+
+    ~IntrusiveList() = default;
+
+    IntrusiveList& operator=(const IntrusiveList&) = delete;
+    IntrusiveList& operator=(IntrusiveList&&) = delete;
+
+    [[nodiscard]] bool empty() const noexcept { return head_ == nullptr; }
+
+    void push_back(T* item) noexcept
+    {
+        item->*Prev = tail_;
+        item->*Next = nullptr;
+        if (tail_ == nullptr)
+            head_ = item;
+        else
+            tail_->*Next = item;
+        tail_ = item;
+    }
+
+    [[nodiscard]] T* pop_front() noexcept
+    {
+        T* item = head_;
+        head_ = item->*Next;
+        if (head_ != nullptr)
+            head_->*Prev = nullptr;
+        else
+            tail_ = nullptr;
+        return item;
+    }
+};
+
+}  // namespace deglib::graph


### PR DESCRIPTION
Motivation see here [https://godbolt.org/z/W9h3servK](https://godbolt.org/z/W9h3servK): pushing back and popping front on a deque leads to the occasional memory allocation. Using an intrusive list that can be avoided completely.